### PR TITLE
refactor: remove ConfigKey to simplify the interface and improve performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ manager.RefreshAndWait()
 Access and retrieve configuration using the provided methods:
 ```
 // define your iface.ConfigKey with a ToString() method
-configKey := NewYourConfigKey(...)
+configKey := "SomeConfigKey"
 
 // it's recommended to retrieve the ConfigValueItem directly:
 maxRetryItem, err := manager.GetConfigItem(configKey, TypeItemMaxRetry)

--- a/config_manager.go
+++ b/config_manager.go
@@ -348,19 +348,19 @@ func (m *ConfigManager) callConfigChangeListeners(differences []iface.ConfigChan
 // GetConfig retrieves the configuration value for the given key from the ConfigManager.
 // If the key is not found, it returns an error indicating the key was not found.
 // If the value of the key is not of type ConfigValue, it panics with an error message.
-func (m *ConfigManager) GetConfig(key iface.ConfigKey) (iface.ConfigValue, error) {
-	if value, ok := m.getCurrentConfigAtomic().Load(key.ToString()); ok {
+func (m *ConfigManager) GetConfig(key string) (iface.ConfigValue, error) {
+	if value, ok := m.getCurrentConfigAtomic().Load(key); ok {
 		if configValue, ok := value.(iface.ConfigValue); ok {
 			return configValue, nil
 		}
-		panic(fmt.Sprintf("GetConfigValue: invalid config Value type for %v", key.ToString())) // should not happen, fail fast
+		panic(fmt.Sprintf("GetConfigValue: invalid config Value type for %v", key)) // should not happen, fail fast
 	}
 	return nil, iface.ErrConfigNotFound
 }
 
 // GetConfigItem retrieves a specific value from the configuration based on the given key and item type.
 // Returns the retrieved configuration value item and an error if unable to retrieve it.
-func (m *ConfigManager) GetConfigItem(key iface.ConfigKey, itemType iface.ItemType) (iface.ConfigValueItem, error) {
+func (m *ConfigManager) GetConfigItem(key string, itemType iface.ItemType) (iface.ConfigValueItem, error) {
 	configValue, err := m.GetConfig(key)
 	if err != nil {
 		return nil, err

--- a/config_manager_test.go
+++ b/config_manager_test.go
@@ -32,15 +32,6 @@ import (
 	"github.com/cloudwego/configmanager/util"
 )
 
-type ConfigKeyUT struct {
-	service string
-	method  string
-}
-
-func (k *ConfigKeyUT) ToString() string {
-	return k.service + "|" + k.method
-}
-
 const itemTypeTest iface.ItemType = "item-test"
 
 var (
@@ -55,15 +46,8 @@ var (
 		"service2|method4": defaultConfig.DeepCopy(),
 	}
 
-	existKey = &ConfigKeyUT{
-		service: "service1",
-		method:  "method1",
-	}
-
-	notExistKey = &ConfigKeyUT{
-		service: "service3",
-		method:  "method5",
-	}
+	existKey    = "service1|method1"
+	notExistKey = "service3|method5"
 
 	sampleConfig = func() iface.ConfigValue {
 		value := defaultConfig.DeepCopy()
@@ -116,7 +100,7 @@ func TestConfigManager_GetConfig(t *testing.T) {
 		currentConfig *sync.Map
 	}
 	type args struct {
-		key iface.ConfigKey
+		key string
 	}
 
 	tests := []struct {
@@ -142,14 +126,14 @@ func TestConfigManager_GetConfig(t *testing.T) {
 			fields: fields{
 				currentConfig: func() *sync.Map {
 					m := &sync.Map{}
-					m.Store(existKey.ToString(), defaultCurrentConfig[existKey.ToString()])
+					m.Store(existKey, defaultCurrentConfig[existKey])
 					return m
 				}(),
 			},
 			args: args{
 				key: existKey,
 			},
-			want:    defaultCurrentConfig[existKey.ToString()],
+			want:    defaultCurrentConfig[existKey],
 			wantErr: nil,
 		},
 	}
@@ -180,7 +164,7 @@ func TestConfigManager_GetConfig(t *testing.T) {
 		m := &ConfigManager{
 			currentConfig: func() *sync.Map {
 				m := &sync.Map{}
-				m.Store(existKey.ToString(), "Value")
+				m.Store(existKey, "Value")
 				return m
 			}(),
 		}
@@ -989,7 +973,7 @@ func TestConfigManager_GetConfigItem(t *testing.T) {
 		currentConfig *sync.Map
 	}
 	type args struct {
-		key      iface.ConfigKey
+		key      string
 		itemType iface.ItemType
 	}
 	tests := []struct {
@@ -1005,10 +989,7 @@ func TestConfigManager_GetConfigItem(t *testing.T) {
 				currentConfig: &sync.Map{},
 			},
 			args: args{
-				key: &ConfigKeyUT{
-					service: "service1",
-					method:  "method1",
-				},
+				key:      "service1|method1",
 				itemType: itemTypeTest,
 			},
 			want:    nil,

--- a/example/main.go
+++ b/example/main.go
@@ -25,25 +25,6 @@ import (
 	"github.com/cloudwego/configmanager/util"
 )
 
-var _ iface.ConfigKey = (*YourConfigKey)(nil)
-
-// YourConfigKey is an example of a custom ConfigKey
-type YourConfigKey struct {
-	Service string
-}
-
-// ToString returns the string representation of the YourConfigKey instance
-func (k *YourConfigKey) ToString() string {
-	return k.Service
-}
-
-// NewYourConfigKey returns a new YourConfigKey
-func NewYourConfigKey(s string) iface.ConfigKey {
-	return &YourConfigKey{
-		Service: s,
-	}
-}
-
 func main() {
 	// define your own item type
 	const TypeItemMaxRetry iface.ItemType = "item-max-retry"
@@ -74,7 +55,7 @@ func main() {
 
 	manager.RefreshAndWait()
 
-	configKey := NewYourConfigKey("test1")
+	configKey := "test1"
 
 	// it's recommended to retrieve the ConfigValueItem directly:
 	maxRetryItem, err := manager.GetConfigItem(configKey, TypeItemMaxRetry)

--- a/iface/definition.go
+++ b/iface/definition.go
@@ -38,11 +38,6 @@ var (
 // LogFunc is used to decouple config manager with logger implementations
 type LogFunc func(format string, args ...interface{})
 
-// ConfigKey defines the key of a config, and is assumed to be associated with a service.
-type ConfigKey interface {
-	ToString() string
-}
-
 // ConfigValue is business related, and config manager don't care about its content.
 type ConfigValue interface {
 	DeepCopy() ConfigValue
@@ -93,8 +88,8 @@ type ConfigManagerIface interface {
 	DeregisterConfigChangeListener(identifier string)
 	Refresh() RefreshCompleteSignal
 	RefreshAndWait() error
-	GetConfig(key ConfigKey) (ConfigValue, error)
-	GetConfigItem(key ConfigKey, itemType ItemType) (ConfigValueItem, error)
+	GetConfig(key string) (ConfigValue, error)
+	GetConfigItem(key string, itemType ItemType) (ConfigValueItem, error)
 	GetAllConfig() map[string]ConfigValue
 	Dump(filepath string) error
 }


### PR DESCRIPTION
**NOTICE**: this PR introduces break change to the API of v0.1.*

#### What type of PR is this?
refactor: A code change that neither fixes a bug nor adds a feature

#### Check the PR title.
- [X] This PR title match the format: \<type\>(optional scope): \<description\>
- [X] The description of this PR title is user-oriented and clear enough for others to understand.
- [X] Attach the PR updating the user documentation if the current PR requires user awareness at the usage level. [User docs repo](https://github.com/cloudwego/cloudwego.github.io)


#### (Optional) Translate the PR title into Chinese.
移除 ConfigKey 接口，直接使用 string，简化API，可以优化性能

#### (Optional) More detailed description for this PR(en: English/zh: Chinese).
en: Kitex uses configmanager, and with v0.1.*, kitex need to build objects from RPCInfo, which has impact on Go GC.
zh(optional): 


#### (Optional) Which issue(s) this PR fixes:

#### (optional) The PR that updates user documentation:
